### PR TITLE
Handle NoneType config env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ export WIS2DOWNLOADER_CONFIG=<path_to_your_config_file>
 set WIS2DOWNLOADER_CONFIG=<path_to_your_config_file>
 ```
 
+*Windows (PowersShell)*
+```
+$env:WIS2DOWNLOADER_CONFIG = <path_to_your_config_file>
+```
 
 2. Start the downloader
 

--- a/wis2downloader/utils/config.py
+++ b/wis2downloader/utils/config.py
@@ -12,6 +12,9 @@ def load_config():
         LOGGER.error("No config file specified, please set WIS2DOWNLOADER_CONFIG before running")
         raise RuntimeError(e)
 
+    if config_file is None:
+        raise ValueError("No config file specified, please set WIS2DOWNLOADER_CONFIG before running")
+
     config_file = Path(config_file)
 
     if not config_file.is_file():

--- a/wis2downloader/utils/config.py
+++ b/wis2downloader/utils/config.py
@@ -4,16 +4,18 @@ from pathlib import Path
 
 from wis2downloader.log import LOGGER
 
+
 def load_config():
 
     try:
         config_file = os.getenv('WIS2DOWNLOADER_CONFIG')
     except Exception as e:
-        LOGGER.error("No config file specified, please set WIS2DOWNLOADER_CONFIG before running")
+        LOGGER.error("No config file specified, please set WIS2DOWNLOADER_CONFIG before running") # noqa
         raise RuntimeError(e)
 
     if config_file is None:
-        raise ValueError("No config file specified, please set WIS2DOWNLOADER_CONFIG before running")
+        raise ValueError(
+            "WIS2DOWNLOADER_CONFIG must be set to an existing config file")
 
     config_file = Path(config_file)
 


### PR DESCRIPTION
To address the [following issue](https://github.com/wmo-im/wis2downloader/issues/20).

**Minor Changes:**
- Added a ValueError when the `WIS2DOWNLOADER_CONFIG` env variable is None.